### PR TITLE
[TASK] use current TYPO3 dependencies

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,9 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => true,
     'version' => '1.0.0',
     'constraints' => [
-        'depends' => [],
+        'depends' => [
+            'typo3' => '9.5.17-10.4.99',
+        ],
         'conflicts' => [],
         'suggests' => []
     ]


### PR DESCRIPTION
use current TYPO3 dependencies, so there is no error message on extensions.typo3.org